### PR TITLE
Fix issue with bvh imported from makehuman

### DIFF
--- a/src/br/ol/animation/bvh/Parser.java
+++ b/src/br/ol/animation/bvh/Parser.java
@@ -42,7 +42,7 @@ public class Parser {
         if (!line.startsWith(token)) {
             throw new RuntimeException("Expected '" + token + "' token !");
         }
-        String[] tokens = line.split("\\ ");
+        String[] tokens = line.split("\\s+");
         nextLine();
         return tokens;
     }


### PR DESCRIPTION
.bvh files imported from MakeHuman have a \t symbol as split symbol after "OFFSET".
That is why they could not be parsed.